### PR TITLE
add osxarm

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -11,6 +11,9 @@ jobs:
       osx_64_:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
+      osx_arm64_:
+        CONFIG: osx_arm64_
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,0 +1,21 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '11'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+macos_machine:
+- arm64-apple-darwin20.0.0
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -19,3 +19,9 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+build_platform:
+- osx-64
+
+CONDA_BUILD_SYSROOT:
+- /Users/ngam/Repos/MacOSX11.0.sdk
+

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -19,9 +19,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-build_platform:
-- osx-64
-
-CONDA_BUILD_SYSROOT:
-- /Users/ngam/Repos/MacOSX11.0.sdk
-

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -40,6 +40,9 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+fi
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -55,6 +55,10 @@ source run_conda_forge_build_setup
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+fi
+
 conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
 ( startgroup "Validating outputs" ) 2> /dev/null
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mbedtls-feedstock?branchName=master&jobName=osx&configuration=osx_64_" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>osx_arm64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=13929&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mbedtls-feedstock?branchName=master&jobName=osx&configuration=osx_arm64_" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,3 +2,7 @@ conda_forge_output_validation: true
 provider:
   linux_aarch64: default
   linux_ppc64le: default
+build_platform:
+  osx_arm64: osx_64
+test_on_native_only: true
+

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,13 +2,26 @@
 
 mkdir build
 
-cmake -B build -S . \
-	${CMAKE_ARGS} \
-	-DCMAKE_INSTALL_PREFIX=$PREFIX \
-	-DCMAKE_INSTALL_LIBDIR=lib \
-	-DCMAKE_BUILD_TYPE=Release \
-	-DCMAKE_VERBOSE_MAKEFILE=ON \
-	-DUSE_SHARED_MBEDTLS_LIBRARY=ON
+if [[ "$target_platform" == osx-arm64 ]]; then
+	cmake -B build -S . \
+		${CMAKE_ARGS} \
+		-DCMAKE_INSTALL_PREFIX=$PREFIX \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_VERBOSE_MAKEFILE=ON \
+		-DUSE_SHARED_MBEDTLS_LIBRARY=ON \
+		-DENABLE_TESTING=Off
+
+else
+	cmake -B build -S . \
+		${CMAKE_ARGS} \
+		-DCMAKE_INSTALL_PREFIX=$PREFIX \
+		-DCMAKE_INSTALL_LIBDIR=lib \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_VERBOSE_MAKEFILE=ON \
+		-DUSE_SHARED_MBEDTLS_LIBRARY=ON
+fi
+
 cmake --build build
 cmake --install build
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   host:
     - python  # [osx and build_platform != target_platform]
   run:
-
+    - python  # [osx and build_platform != target_platform]
 test:
   commands:
     - mbedtls_hello

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ requirements:
   build:
     - cmake
     - make
+    - python  # [osx and build_platform != target_platform]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
+    - python  # [osx and build_platform != target_platform]
   run:
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - cmake
     - make
     - python  # [osx and build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [osx and build_platform != target_platform]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,14 +17,11 @@ requirements:
   build:
     - cmake
     - make
-    - python  # [osx and build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [osx and build_platform != target_platform]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - python  # [osx and build_platform != target_platform]
   run:
-    - python  # [osx and build_platform != target_platform]
+
 test:
   commands:
     - mbedtls_hello


### PR DESCRIPTION
Fixes #5 
- MNT: Re-rendered with conda-build 3.21.7, conda-smithy 3.16.1, and conda-forge-pinning 2022.01.05.14.36.24
- add osxarm
